### PR TITLE
Limit Bazel to available CCI resources of 3072 MB (of 4096 max) & 2 core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           key: angular_bazel_example-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run: bazel info release
       - run: bazel run @yarn//:yarn
-      - run: bazel build ...
+      - run: bazel build --local_resources=3072,2.0,1.0 ...
 
       - save_cache:
           key: angular_bazel_example-{{ .Branch }}-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
Should fix https://github.com/bazelbuild/bazel/issues/3645.

Issue as far as I can tell is that Bazel was assuming the available resources were much higher than then actually were (the machine the docker container runs on has a ton of resources but CCI limits the container to 4096 MB and 2 cores). During SASS compilation especially there are a lot of gcc calls being launched in parallel which seemed to exceed the 4096 MB max most of the time and kill the build.

Add --local_resources=3072,2.0,1.0 to the bazel build command limits the build to resources to the amounts that CCI allows by default.