### PR TITLE
Serve the app with a devserver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/ng
     docker:
-      - image: angular/ngcontainer:0.0.1
+      - image: angular/ngcontainer:0.0.6
     steps:
       - checkout
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
-bazel-*
+bazel-out
 .bazelrc
+dist

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,43 @@
 package(default_visibility = ["//visibility:public"])
 exports_files(["tsconfig.json"])
 
+filegroup(
+    name = "static_scripts",
+    srcs = [
+        "node_modules/zone.js/dist/zone.min.js",
+        "node_modules/@angular/common/bundles/common.umd.js",
+        "node_modules/@angular/platform-browser/bundles/platform-browser.umd.js",
+        "node_modules/@angular/core/bundles/core.umd.js",
+        "node_modules/requirejs/require.js",
+    ],
+)
+
 # NOTE: this will move to node_modules/BUILD in a later release
-filegroup(name = "node_modules", srcs = glob([
-    "node_modules/**/*.js",
-    "node_modules/**/*.json",
-    "node_modules/**/*.d.ts",
-]))
+filegroup(
+    name = "node_modules",
+    # NB: rxjs is not in this list, because we build it from sources using the
+    # label @rxjs//:rxjs
+    srcs = glob(["/".join(["node_modules", pkg, "**", ext]) for pkg in [
+        "@angular",
+        "tsickle",
+        "tsutils",
+        "typescript",
+        "@types",
+    ] for ext in [
+        "*.js",
+        "*.json",
+        "*.d.ts",
+    ]]),
+)
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_devserver")
+
+ts_devserver(
+  name = "devserver",
+  deps = ["//src"],
+  serving_path = "/bundle.js",
+  static_files = [
+    "//src:static_files",
+    "//:static_scripts",
+  ],
+)

--- a/README.md
+++ b/README.md
@@ -4,27 +4,22 @@
 
 **This is experimental! There may be breaking changes.**
 
-## Installation
+This is part of the ABC project. See http://g.co/ng/abc for an overview.
 
-Mac: `brew install bazel`
+See the documentation in the wiki of this repository to install the
+necessary dependencies and understand how this works.
 
-Other platforms, see Bazel [installation instructions].
-
-[installation instructions]: https://bazel.build/versions/master/docs/install.html
-
-`ibazel` is a watch mode for Bazel. We recommend installing this from
-https://github.com/bazelbuild/bazel-watcher.
-
-`dot` is a handy tool for visualizing dependency graphs, and is used in some commands below.
-On Mac: `brew install graphviz`
+Follow https://github.com/angular/angular/issues/19058 for updates.
 
 ## Try it
 
 ```bash
 # Install packages, uses hermetic version of node and yarn
 $ bazel run @yarn//:yarn
-$ ibazel build src
-# Make changes, observe the development round-trip time
+# Start up the devserver in watch mode
+$ ./node_modules/.bin/ibazel run :devserver
+# Open the URL printed on your terminal.
+# Make changes to sources, observe the development round-trip time
 ```
 
 Look at the dependency graph:
@@ -40,12 +35,10 @@ $ bazel query --output=graph ... | dot -Tpng > graph.png
 
 Karma testing rules are in-progress, should be available Q4 2017
 
-Doesn't include devserver. Can use webpack as the development server, see https://github.com/gregmagolan/abc-demo-build-with-aot-universal
-
 Production bundling with https://github.com/bazelbuild/rules_closure/ is
 underway, should be available Q4 2017
 
 ## Notes
 
-- we use bazel to run yarn simply to be sure we get the same versions of Node and Yarn as CI and co-workers (hermeticity FTW)
+- we use Bazel to run Yarn simply to be sure we get the same versions of Node and Yarn as CI and co-workers (hermeticity FTW). You could use NPM instead
 - a `postinstall` task in the `package.json` prepares the `node_modules` directory by running the Angular compiler on third_party libraries (such as Angular itself) since these do not ship with generated code (eg. `ngfactory`s)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,20 +1,32 @@
+workspace(name = "angular_bazel_example")
+
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.1.8",
+    tag = "0.3.0",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 node_repositories(package_json = ["//:package.json"])
 
-local_repository(
+git_repository(
     name = "build_bazel_rules_typescript",
-    path = "node_modules/@bazel/typescript",
+    remote = "https://github.com/bazelbuild/rules_typescript.git",
+    tag = "0.6.0",
 )
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_repositories")
+
+ts_repositories()
 
 local_repository(
     name = "angular",
     path = "node_modules/@angular/bazel",
+)
+
+local_repository(
+    name = "rxjs",
+    path = "node_modules/rxjs/src",
 )
 
 git_repository(
@@ -26,3 +38,15 @@ git_repository(
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
 
 sass_repositories()
+
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.7.1/rules_go-0.7.1.tar.gz",
+    sha256 = "341d5eacef704415386974bc82a1783a8b7ffbff2ab6ba02375e1ca20d9b031c",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+
+go_register_toolchains()

--- a/package.json
+++ b/package.json
@@ -4,18 +4,21 @@
     "description": "Demo of bazel rules for angular",
     "license": "Apache 2.0",
     "dependencies": {
-        "@angular/animations": "5.0.x",
-        "@angular/common": "5.0.x",
-        "@angular/core": "5.0.x",
-        "@angular/platform-browser": "5.0.x",
-        "rxjs": "5.5.x",
+        "@angular/animations": "5.1.0",
+        "@angular/common": "5.1.0",
+        "@angular/core": "5.1.0",
+        "@angular/platform-browser": "5.1.0",
+        "rxjs": "5.5.5",
         "zone.js": "~0.8.13"
     },
     "devDependencies": {
-        "@angular/bazel": "5.0.x",
-        "@angular/compiler": "5.0.x",
-        "@angular/compiler-cli": "5.0.x",
-        "typescript": "~2.4.x"
+        "@angular/bazel": "5.1.0",
+        "@angular/compiler": "5.1.0",
+        "@angular/compiler-cli": "5.1.0",
+        "@bazel/ibazel": "~0.1.1",
+        "@bazel/typescript": "bazelbuild/rules_typescript",
+        "requirejs": "^2.3.5",
+        "typescript": "~2.5.x"
     },
     "scripts": {
         "postinstall": "ngc -p angular.tsconfig.json",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -8,3 +8,8 @@ ng_module(
   deps = ["//src/hello-world"],
   tsconfig = ":tsconfig.json",
 )
+
+filegroup(
+  name = "static_files",
+  srcs = ["index.html"],
+)

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,17 @@
-import {HelloWorldModule} from './hello-world/hello-world.module';
 
-import {NgModule} from '@angular/core';
+import {NgModule, Component} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+import { HelloWorldModule } from './hello-world/hello-world.module';
+
+@Component({
+  selector: 'app-component',
+  template: '<hello-world-app></hello-world-app>'
+})
+export class BootstrapComponent {}
 
 @NgModule({
   imports: [BrowserModule, HelloWorldModule],
+  declarations: [BootstrapComponent],
+  bootstrap: [BootstrapComponent],
 })
 export class AppModule {}

--- a/src/hello-world/BUILD.bazel
+++ b/src/hello-world/BUILD.bazel
@@ -15,7 +15,10 @@ sass_binary(
 ng_module(
   name = "hello-world",
   srcs = glob(["*.ts"]),
-  deps = ["//src/lib"],
+  deps = [
+    "//src/lib",
+    "@rxjs//:rxjs",
+  ],
   assets = [":hello-world-styles"],
   tsconfig = "//src:tsconfig.json",
 )

--- a/src/hello-world/hello-world.module.ts
+++ b/src/hello-world/hello-world.module.ts
@@ -4,7 +4,7 @@ import {HelloWorldComponent} from './hello-world.component';
 
 @NgModule({
   declarations: [HelloWorldComponent],
-  bootstrap: [HelloWorldComponent],
+  exports: [HelloWorldComponent],
 })
 export class HelloWorldModule {
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+
+<html>
+  <head>
+    <title>Angular Bazel Example</title>
+  </head>
+  <body>
+    <app-component></app-component>
+    <script src="/node_modules/zone.js/dist/zone.min.js"></script>
+
+    <script src="/node_modules/requirejs/require.js"></script>
+    <!--
+      For development mode, this script will be bundled on-the-fly by
+      the devserver, based on the latest JS files built by Bazel.
+      For production, you should be able to use the same index.html file, but
+      this JS resource would be served from a static file.
+    -->
+    <script src="/bundle.js"></script>
+
+    <script src="/node_modules/@angular/core/bundles/core.umd.js"></script>
+    <script src="/node_modules/@angular/common/bundles/common.umd.js"></script>
+    <script src="/node_modules/@angular/platform-browser/bundles/platform-browser.umd.js"></script>
+
+    <script>require(['angular_bazel_example/src/main'])</script>
+  </body>
+</html>

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -8,7 +8,7 @@ build --strategy=TypeScriptCompile=worker
 # which affects the common case of having `tsconfig.json` in the WORKSPACE directory.
 #
 # Instead, you should run `bazel info bazel-bin` to find out where the outputs went.
-build --symlink_prefix=/
+build --symlink_prefix=dist/
 
 # Workaround rules_sass still using old 'set' constructor
 # This is an error in bazel >= 0.6 unless this flag is set

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,61 +2,69 @@
 # yarn lockfile v1
 
 
-"@angular/animations@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.0.0.tgz#b5ad199c67f93f759544477effe6679e154991fb"
+"@angular/animations@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.1.0.tgz#439135ed56355ec779791bf3ea7de1c711cd2185"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/bazel@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-5.0.0.tgz#c6457f095d157f6d4b2314721a3d35e1654912d4"
+"@angular/bazel@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/bazel/-/bazel-5.1.0.tgz#34b01ec7d49f64843c2723856043d366fe4da036"
   dependencies:
-    "@bazel/typescript" "0.2.x"
+    "@bazel/typescript" "0.3.2"
     "@types/node" "6.0.84"
 
-"@angular/common@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.0.0.tgz#f96d66a517b995d1ba9b28309f15c2e359675825"
+"@angular/common@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.1.0.tgz#88b586e0aff6a93b8de08cce1e14c0e65fde5a56"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/compiler-cli@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.0.0.tgz#0ecbb937d84a4f8dd94f0c2a47b07d2e4694c853"
+"@angular/compiler-cli@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-5.1.0.tgz#9512abf2515c7d3b7e9ee45650801ee78d63223e"
   dependencies:
     chokidar "^1.4.2"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
-    tsickle "^0.24.0"
+    tsickle "^0.25.5"
 
-"@angular/compiler@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.0.0.tgz#b9ffbf18c8a39d8b7dacec473193a90e24cc2bc9"
+"@angular/compiler@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.1.0.tgz#23fe2914061487fcc909616b4dc5c24c5a8d47a1"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/core@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.0.0.tgz#4f976a225f7dddf34992f2cad824c9543a46f4c8"
+"@angular/core@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.1.0.tgz#6f7596ad780418cecac527ae0508cfc1a36383a0"
   dependencies:
     tslib "^1.7.1"
 
-"@angular/platform-browser@5.0.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.0.0.tgz#c7038f7cde80705b62014897231e182eec976fed"
+"@angular/platform-browser@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.1.0.tgz#b5373232403d73c355b971cfae8b03191c4f58a2"
   dependencies:
     tslib "^1.7.1"
 
-"@bazel/typescript@0.2.x":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.2.2.tgz#0a0d09924508c946de32e6acdb2b5cc1ee32c506"
+"@bazel/ibazel@~0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.1.1.tgz#f970c08b4e4efb0ab17e04ade3cc610554f33bed"
+
+"@bazel/typescript@0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.3.2.tgz#b4721b7f9e4c447a553555eab4a437f538a9496d"
   dependencies:
     "@types/node" "7.0.18"
     "@types/source-map" "^0.5.1"
     protobufjs "5.0.0"
-    tsickle "0.24.x"
-    typescript "2.4.x"
+    tsickle "0.25.x"
+    typescript "2.5.x"
+
+"@bazel/typescript@bazelbuild/rules_typescript":
+  version "0.6.0"
+  resolved "https://codeload.github.com/bazelbuild/rules_typescript/tar.gz/b5fe4f51fc1c57a484f7daf5d555d494d0fe1854"
 
 "@types/node@6.0.84":
   version "6.0.84"
@@ -67,8 +75,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
 "@types/source-map@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.1.tgz#7e74db5d06ab373a712356eebfaea2fad0ea2367"
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.2.tgz#973459e744cc7445c85b97f770275b479b138e08"
 
 abbrev@1:
   version "1.1.1"
@@ -163,8 +171,8 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 binary-extensions@^1.0.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
 block-stream@*:
   version "0.0.9"
@@ -294,6 +302,10 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -367,11 +379,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.36"
+    node-pre-gyp "^0.6.39"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -495,8 +507,8 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 invert-kv@^1.0.0:
   version "1.0.0"
@@ -509,8 +521,8 @@ is-binary-path@^1.0.0:
     binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -686,13 +698,14 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 nan@^2.3.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
-node-pre-gyp@^0.6.36:
-  version "0.6.38"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz#e92a20f83416415bb4086f6d1fb78b3da73d113d"
+node-pre-gyp@^0.6.39:
+  version "0.6.39"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
+    detect-libc "^1.0.2"
     hawk "3.1.3"
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -826,8 +839,8 @@ randomatic@^1.1.3:
     kind-of "^4.0.0"
 
 rc@^1.1.7:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
     deep-extend "~0.4.0"
     ini "~1.3.0"
@@ -904,17 +917,21 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+requirejs@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.5.tgz#617b9acbbcb336540ef4914d790323a8d4b861b0"
+
 rimraf@2, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
-rxjs@5.5.x:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
+rxjs@5.5.5:
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.5.tgz#e164f11d38eaf29f56f08c3447f74ff02dd84e97"
   dependencies:
-    symbol-observable "^1.0.1"
+    symbol-observable "1.0.1"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -994,13 +1011,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-symbol-observable@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 tar-pack@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
   dependencies:
     debug "^2.2.0"
     fstream "^1.0.10"
@@ -1025,9 +1042,9 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-tsickle@0.24.x, tsickle@^0.24.0:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.24.1.tgz#039343b205bf517a333b0703978892f80a7d848e"
+tsickle@0.25.x, tsickle@^0.25.5:
+  version "0.25.5"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.25.5.tgz#2891d29f97c4aab1306e06378d8496d1765a4bfe"
   dependencies:
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -1035,8 +1052,8 @@ tsickle@0.24.x, tsickle@^0.24.0:
     source-map-support "^0.4.2"
 
 tslib@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -1048,9 +1065,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@2.4.x, typescript@~2.4.x:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@2.5.x, typescript@~2.5.x:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
To try it:

```
./node_modules/.bin/ibazel run :devserver
# prints Server listening on http://myhost:5432/
# open http://myhost:5432/src in browser
```

TODO before landing:
- make livereload work, /cc @gregmagolan 
- get an rxjs release with the bits we need rather than using Greg's fork
- don't require me to go to `/src` in the browser, serve it at root