### PR TITLE
Repro of Angular Material Bazel compilation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
     "license": "Apache 2.0",
     "dependencies": {
         "@angular/animations": "5.2.0",
+        "@angular/cdk": "^5.1.0",
         "@angular/common": "5.2.0",
         "@angular/core": "5.2.0",
+        "@angular/forms": "^5.2.1",
+        "@angular/material": "^5.1.0",
         "@angular/platform-browser": "5.2.0",
         "rxjs": "5.5.6",
         "zone.js": "0.8.20"

--- a/src/hello-world/hello-world.module.ts
+++ b/src/hello-world/hello-world.module.ts
@@ -1,9 +1,10 @@
 import {NgModule} from '@angular/core';
-
+import {MatButtonModule} from '@angular/material';
 import {HelloWorldComponent} from './hello-world.component';
 
 @NgModule({
   declarations: [HelloWorldComponent],
+  imports: [MatButtonModule],
   exports: [HelloWorldComponent],
 })
 export class HelloWorldModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,12 @@
   dependencies:
     "@types/node" "6.0.84"
 
+"@angular/cdk@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-5.1.0.tgz#e04547609d96d8b6fe0dac17bed323760c3952e9"
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/common@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.2.0.tgz#d184fb90763da1d1bab1f6c4f41dd80c79e47506"
@@ -38,6 +44,18 @@
 "@angular/core@5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.2.0.tgz#f91bf83de3e0defd621adcc007c25d7cd5a85af1"
+  dependencies:
+    tslib "^1.7.1"
+
+"@angular/forms@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-5.2.1.tgz#530f1249bc71d9560297be642d55a5a6c439d920"
+  dependencies:
+    tslib "^1.7.1"
+
+"@angular/material@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-5.1.0.tgz#038803b6a52e484c6bf9bb413714795952d61d49"
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
Angular Material 5.1.0 (and 5.0.x) currently encounters compilation errors when consumed from an Angular/Bazel app. Here is an example repro which fails to build. The failure shows up when running `bazel build //src`.

The error is `Could not resolve ./index.ngfactory from [....]/angular_bazel_example/node_modules/@angular/material/button/typings/index.d.ts`.

I've confirmed that `node_modules/@angular/material/button/typings/index.ngfactory.js` is present in the workspace, so I'm not sure why the import can't be resolved.

Though this repro uses MatButtonModule, I think almost any Angular Material NgModule will similarly fail; MatButtonModule was chosen arbitrarily.