### PR TITLE
Example of silent ngc-wrapped failure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
         "tsutils",
         "typescript",
         "@types",
+        "angularfire2",
     ] for ext in [
         "*.js",
         "*.json",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
         "@angular/common": "5.2.0",
         "@angular/core": "5.2.0",
         "@angular/platform-browser": "5.2.0",
+        "angularfire2": "^5.0.0-rc.4",
+        "firestore": "^1.1.6",
         "rxjs": "5.5.6",
         "zone.js": "0.8.20"
     },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
-
 import {NgModule, Component} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
+
+import {AngularFirestoreModule} from 'angularfire2/firestore';
+
 import { HelloWorldModule } from './hello-world/hello-world.module';
 
 @Component({
@@ -10,7 +12,7 @@ import { HelloWorldModule } from './hello-world/hello-world.module';
 export class BootstrapComponent {}
 
 @NgModule({
-  imports: [BrowserModule, HelloWorldModule],
+  imports: [BrowserModule, AngularFirestoreModule, HelloWorldModule],
   declarations: [BootstrapComponent],
   bootstrap: [BootstrapComponent],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,10 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+angularfire2@^5.0.0-rc.4:
+  version "5.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/angularfire2/-/angularfire2-5.0.0-rc.4.tgz#65c4d2ed768c3251b0b611ce51d6b42ac8afeabc"
+
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
@@ -764,6 +768,12 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
+faye-websocket@>=0.6.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
+  dependencies:
+    websocket-driver ">=0.5.1"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -794,6 +804,24 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+firebase-token-generator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/firebase-token-generator/-/firebase-token-generator-2.0.0.tgz#9767d759ec13abdc99ba115fd5ea99d8b93d1206"
+
+firebase@^2.1.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-2.4.2.tgz#4e1119ec0396ca561d8a7acbff1630feac6c0a31"
+  dependencies:
+    faye-websocket ">=0.6.0"
+
+firestore@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/firestore/-/firestore-1.1.6.tgz#73284bce9fe9b08bdad6c18278d25b696e123cc2"
+  dependencies:
+    firebase "^2.1.2"
+    firebase-token-generator "^2.0.0"
+    lodash "^3.1.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -1029,6 +1057,10 @@ http-errors@~1.6.1:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
+
+http-parser-js@>=0.4.0:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.9.tgz#ea1a04fb64adff0242e9974f297dd4c3cad271e1"
 
 http-proxy@1.15.2:
   version "1.15.2"
@@ -1352,7 +1384,7 @@ lodash.isfinite@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
 
-lodash@^3.10.1:
+lodash@^3.1.0, lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
@@ -2347,6 +2379,17 @@ webdriver-manager@^12.0.6:
     rimraf "^2.5.2"
     semver "^5.3.0"
     xml2js "^0.4.17"
+
+websocket-driver@>=0.5.1:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
+  dependencies:
+    http-parser-js ">=0.4.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hey Alex, I've run into this on a few separate occasions, so here's an example repro. Basically, ngc-wrapped appears to be crashing / failing silently in cases like this, making it difficult to know what went wrong. The problem ends up being detected later, when trying to import an ngfactory file that was never created.

### Reproduction steps

Run `bazel build //src` from this branch.

### Error observed

```
ERROR: [path_to_workspace]/src/BUILD.bazel:5:1: Compiling Angular templates (ngc) //src:src failed (Exit 1)
src/main.ts(2,34): error TS2307: Cannot find module './app.ngfactory'.

Target //src:src failed to build
```

It seems in this case that `app.ngfactory.js` is created but never populated with content due to ngc-wrapped crashing part of the way through.

Note that if I put the error-causing module import in the `hello-world` module instead of `src`, ngc correctly terminates with an error message: ```ERROR:  [path_to_workspace]/src/hello-world/BUILD.bazel:16:1: Compiling Angular templates (ngc) //src/hello-world:hello-world failed (Exit 1)
: Unexpected value 'AngularFirestoreModule in [redacted]/bazel-sandbox/1851362310346190182/execroot/angular_bazel_example/node_modules/angularfire2/firestore/index.d.ts' imported by the module 'HelloWorldModule in [redacted]/bazel-sandbox/1851362310346190182/execroot/angular_bazel_example/src/hello-world/hello-world.module.ts'. Please add a @NgModule annotation.```