### PR TITLE
Make AngularTemplateCompile also use a persistent worker.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,6 +1,7 @@
-# Make TypeScript compilation fast, by keeping a few copies of the compiler
-# running as daemons, and cache SourceFile AST's to reduce parse time.
+# Make TypeScript and Angular compilation fast, by keeping a few copies of the
+# compiler running as daemons, and cache SourceFile AST's to reduce parse time.
 build --strategy=TypeScriptCompile=worker
+build --strategy=AngularTemplateCompile=worker
 
 # Don't create bazel-* symlinks in the WORKSPACE directory.
 # These require .gitignore and may scare users.


### PR DESCRIPTION
This brings down compilation time of editing
src/hello-world/hello-world.component.ts from 3.8s to 1.2s on my
machine.