### PR TITLE
Add missing bazel packages

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -25,6 +25,8 @@ ng_module(
         "//src/material",
         "//src/todos",
         "@angular//packages/core",
+        "@angular//packages/platform-browser",
+        "@angular//packages/platform-browser/animations",
         "@angular//packages/router",
         "@npm//@ngrx/store",
     ],


### PR DESCRIPTION
Remote build execution of this project fails if these two packages are not included